### PR TITLE
Avoid the doubledot issue in quoted-printable mail

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -814,6 +814,10 @@ class CMailFile
 				if (!empty($conf->global->$keyforsmtppw)) $this->transport->setPassword($conf->global->$keyforsmtppw);
 				//$smtps->_msgReplyTo  = 'reply@web.com';
 
+				// Switch content encoding to base64 - avoid the doubledot issue with quoted-printable
+                $contentEncoderBase64 = new Swift_Mime_ContentEncoder_Base64ContentEncoder();
+                $this->message->setEncoder($contentEncoderBase64);
+				
 				// Create the Mailer using your created Transport
 				$this->mailer = new Swift_Mailer($this->transport);
 


### PR DESCRIPTION
When sending HTML mail using swiftmailer, the content will be encoded using quoted-printable. We may then encounter the "double dot" issue (doubled dot at the beginning of the line). This can be problematic with broken links to pictures for example.
This PR switches the encoding to base64.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
